### PR TITLE
setup.py: Add url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ README = codecs.open('README.rst', encoding='utf-8').read()
 
 setup(
     name="tsuru-feaas",
+    url="https://github.com/tsuru/varnishapi",
     version=__version__,
     description="Frontend as-a-service API for Tsuru PaaS",
     long_description=README,


### PR DESCRIPTION
Especially important since PyPI name ("tsuru-feaas") doesn't match GitHub repo name ("tsuru/varnishapi") so I had trouble locating the repo for a while.